### PR TITLE
Update hive-security.md

### DIFF
--- a/docs/src/main/sphinx/connector/hive-security.md
+++ b/docs/src/main/sphinx/connector/hive-security.md
@@ -190,8 +190,8 @@ section {ref}`configuring-hadoop-impersonation`. Kerberos is not used.
 
 ```text
 hive.hdfs.authentication.type=KERBEROS
-hive.hdfs.trino.principal=hdfs@EXAMPLE.COM
-hive.hdfs.trino.keytab=/etc/trino/hdfs.keytab
+hive.hdfs.trino.principal=trino@EXAMPLE.COM
+hive.hdfs.trino.keytab=/etc/trino/trino.keytab
 ```
 
 When the authentication type is `KERBEROS`, Trino accesses HDFS as the
@@ -211,7 +211,7 @@ Keytab files must be distributed to every node in the cluster that runs Trino.
 hive.hdfs.authentication.type=KERBEROS
 hive.hdfs.impersonation.enabled=true
 hive.hdfs.trino.principal=trino@EXAMPLE.COM
-hive.hdfs.trino.keytab=/etc/trino/hdfs.keytab
+hive.hdfs.trino.keytab=/etc/trino/trino.keytab
 ```
 
 When using `KERBEROS` authentication with impersonation, Trino impersonates


### PR DESCRIPTION
Description: When setting up Trino, I encountered a misconfiguration error with the hive.hdfs.trino.keytab property. The property should point to the location of the keytab file for the principal specified by hive.hdfs.trino.principal. 

Steps to reproduce:

Set hive.hdfs.trino.keytab=/etc/trino/hdfs.keytab in the Trino configuration. Start the Trino server.

Observe the error.
Expected Behavior: Trino server starts without any errors.

Actual Behavior: An error is thrown indicating an issue with hive.hdfs.trino.keytab.
hive.hdfs.trino.principal

This property specifies the Kerberos principal that Trino uses when connecting to HDFS.

Example: hive.hdfs.trino.principal=trino-hdfs-superuser/trino-server-node@EXAMPLE.COM

In this example, Trino will authenticate to HDFS using the specified principal. If each worker node has its own Kerberos principal, you can use the _HOST placeholder, which will be replaced by the hostname of the worker node Trino is running on.

Example: hive.hdfs.trino.principal=trino-hdfs-superuser/_HOST@EXAMPLE.COM

hive.hdfs.trino.keytab

This property specifies the path to the keytab file that contains a key for the principal specified by hive.hdfs.trino.principal. This file must be readable by the operating system user running Trino.

Example: hive.hdfs.trino.keytab=/etc/trino/trino.keytab

In this example, the keytab file is located at /etc/trino/trino.keytab and should contain a key for the principal trino-hdfs-superuser/trino-server-node@EXAMPLE.COM or trino-hdfs-superuser/_HOST@EXAMPLE.COM, depending on what was specified in hive.hdfs.trino.principal

<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description



<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can. -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
# Section
* Fix some things. ({issue}`issuenumber`)
```
